### PR TITLE
Use electron-prebuilt for a cross-platform npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "luin <i@zihua.li> (http://zihua.li)",
   "main": "server/main.js",
   "scripts": {
-    "start": "rm Medis.app/Contents/Resources/app.asar; NODE_ENV=debug Medis.app/Contents/MacOS/Electron .",
+    "start": "NODE_ENV=debug electron .",
     "dev": "./bin/dev",
     "deploy": "NODE_ENV=production ./bin/deploy",
     "release": "NODE_ENV=production ./bin/release",
@@ -57,6 +57,7 @@
     "conventional-github-releaser": "^0.5.3",
     "css-loader": "^0.19.0",
     "cz-conventional-changelog": "^1.1.5",
+    "electron-prebuilt": "^0.37.7",
     "eslint-plugin-react": "^3.15.0",
     "github": "^0.2.4",
     "jsx-loader": "^0.13.2",


### PR DESCRIPTION
With this PR, modifying only ``package.json`` (+1 dep, 1 modified script), the project can be run on any Electron-compatible platform.
I was going to start working on packaging but as #21 is on its way tell me if it's interesting or not.