### PR TITLE
change: upgrade to webpack 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "node-sass": "^3.3.3",
     "sass-loader": "^3.0.0",
     "style-loader": "^0.12.4",
-    "webpack": "^1.12.2",
-    "webpack-dev-server": "^1.12.0"
+    "webpack": "^2.2.0-rc.1",
+    "webpack-dev-server": "^2.2.0-rc.0"
   },
   "config": {
     "commitizen": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,20 +14,20 @@ module.exports = {
     // publicPath: 'http://localhost:8090/assets'
   },
   module: {
-    loaders: [{
+    rules: [{
       test: /\.jsx$/,
       exclude: /node_modules/,
-      loader: 'jsx-loader?harmony!babel?stage=0&ignore=buffer'
+      loader: 'jsx-loader?harmony!babel-loader?stage=0&ignore=buffer'
     }, {
       test: /\.js$/,
       exclude: /node_modules/,
-      loader: 'babel?stage=0&ignore=buffer'
+      loader: 'babel-loader?stage=0&ignore=buffer'
     }, {
       test: /\.scss$/,
-      loader: 'style!css!sass'
+      loader: 'style-loader!css-loader!sass-loader'
     }, {
       test: /\.css$/,
-      loader: 'style!css'
+      loader: 'style-loader!css-loader'
     }, {
       test: /\.(png|jpg)$/,
       loader: "url-loader"
@@ -49,6 +49,6 @@ module.exports = {
     'file': '{}'
   },
   resolve: {
-    extensions: ['', '.js', '.jsx']
+    extensions: ['.js', '.jsx']
   }
 };


### PR DESCRIPTION
ref: http://javascriptplayground.com/blog/2016/10/moving-to-webpack-2/<Paste>

KNOWN ISSUES:

as webpack complains:

```

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (250 kB).
This can impact web performance.
Assets:
  main.js (3.15 MB)
  pattern-manager.js (1.37 MB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (250 kB). This can impact web performance.
Entrypoints:
  main (3.15 MB)
      main.js

  pattern-manager (1.37 MB)
      pattern-manager.js

WARNING in webpack performance recommendations:
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/
```