### PR TITLE
Refresh codemirror when it unhides

### DIFF
--- a/client/components/main/Main/Database/Content/KeyContent/Editor.jsx
+++ b/client/components/main/Main/Database/Content/KeyContent/Editor.jsx
@@ -44,6 +44,7 @@ class Editor extends React.Component {
     } else {
       $(ReactDOM.findDOMNode(this.refs.wrapSelector)).show();
     }
+    this.refs.codemirror.getCodeMirror().refresh();
   }
 
   componentDidMount() {


### PR DESCRIPTION
Couldn't find a ticket about this but the editor renders badly in certain occasions:

to reproduce:
1. select a key
2. open 'Terminal'
3. select another key with the terminal open
4. open 'Content'

then you get something like this:
![screen shot 2017-03-29 at 10 44 37](https://cloud.githubusercontent.com/assets/2109932/24446329/5f9839e6-146d-11e7-892e-b8cb5c1cf788.png)

The solution is refreshing the codemirror when it unhides. here's the corresponding issue https://github.com/JedWatson/react-codemirror/issues/6