### PR TITLE
There's no build command in the latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can download compiled versions of Medis for Mac OS X from [the release page]
 
 2. Compile assets:
 
-    $ npm run build
+    $ npm run deploy
 
 3. Run with Electron:
 


### PR DESCRIPTION
Looking at the package.json there's no script named `build`.

I didn't know which command was the right one, the `deploy` or `release` sooo...