### PR TITLE
Fix Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can download compiled versions of Medis for Mac OS X from [the release page]
 ```
 2. Compile assets:
 ```
-    $ npm run build
+    $ npm run deploy
 ```
 3. Run with Electron:
 ```


### PR DESCRIPTION
`npm run deploy` is required instead of `npm run build` for compilation from source to work correctly