### PR TITLE
197 pattern history

### DIFF
--- a/src/renderer/windows/MainWindow/InstanceContent/DatabaseContainer/KeyBrowser/PatternList/index.jsx
+++ b/src/renderer/windows/MainWindow/InstanceContent/DatabaseContainer/KeyBrowser/PatternList/index.jsx
@@ -10,7 +10,8 @@ class PatternList extends React.Component {
     super()
     this.state = {
       patternDropdown: false,
-      pattern: props.pattern
+      pattern: props.pattern,
+      patternHistory: []
     }
   }
 
@@ -28,6 +29,21 @@ class PatternList extends React.Component {
     this.props.onChange(value)
   }
 
+  updatePatternHistory(value) {
+    const i = this.state.patternHistory.indexOf(value)
+    if(i != -1)  this.state.patternHistory.splice(index, 1)
+    this.state.patternHistory.unshift(value)
+    this.setState({
+      patternHistory: this.state.patternHistory.slice(0,5)
+    })
+  }
+
+  handleKeyDown(evt) {
+    if (evt.key === 'Enter') {
+      this.updatePatternHistory(evt.target.value)
+    }
+  }
+
   render() {
     return (<div className="pattern-input">
       <span className="icon icon-search"/>
@@ -39,6 +55,7 @@ class PatternList extends React.Component {
         onChange={evt => {
           this.updatePattern(evt.target.value)
         }}
+        onKeyDown={evt => this.handleKeyDown(evt)}
         />
       <span
         className={'js-pattern-dropdown icon icon-down-open' + (this.state.patternDropdown ? ' is-active' : '')}
@@ -52,14 +69,34 @@ class PatternList extends React.Component {
         >
         <ul>
           {
+            this.state.patternHistory.map(pattern => {
+              return (<li
+                  key={pattern}
+                  onClick={() => {
+                    const value = pattern
+                    this.props.onChange(value)
+                    this.setState({patternDropdown: false, pattern: value})
+                    this.updatePatternHistory(value)
+                  }}
+                >{pattern}</li>)
+            })
+          }
+        </ul>
+        { this.props.pattern.length && this.state.patternHistory.length
+            && <div className='list-divider'/>
+            || null
+        }
+        <ul>
+          {
             this.props.patterns.map(pattern => {
               return (<li
-                key={pattern.get('key')} onClick={() => {
-                  const value = pattern.get('value')
-                  this.props.onChange(value)
-                  this.setState({patternDropdown: false, pattern: value})
-                }}
-                                         >{pattern.get('name')}</li>)
+                  key={pattern.get('key')}
+                  onClick={() => {
+                    const value = pattern.get('value')
+                    this.props.onChange(value)
+                    this.setState({patternDropdown: false, pattern: value})
+                  }}
+                >{pattern.get('name')}</li>)
             })
           }
           <li

--- a/src/renderer/windows/MainWindow/InstanceContent/DatabaseContainer/KeyBrowser/PatternList/index.jsx
+++ b/src/renderer/windows/MainWindow/InstanceContent/DatabaseContainer/KeyBrowser/PatternList/index.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import {ipcRenderer} from 'electron'
+import {List} from "immutable"
 
 require('./index.scss')
 
@@ -11,7 +12,7 @@ class PatternList extends React.Component {
     this.state = {
       patternDropdown: false,
       pattern: props.pattern,
-      patternHistory: []
+      patternHistory: new List()
     }
   }
 
@@ -30,11 +31,12 @@ class PatternList extends React.Component {
   }
 
   updatePatternHistory(value) {
-    const i = this.state.patternHistory.indexOf(value)
-    if(i != -1)  this.state.patternHistory.splice(index, 1)
-    this.state.patternHistory.unshift(value)
+    let history = this.state.patternHistory
+    const i = history.indexOf(value)
+    if(i != -1)  history = history.remove(index)
+    history = history.unshift(value)
     this.setState({
-      patternHistory: this.state.patternHistory.slice(0,5)
+      patternHistory: history.slice(0,5)
     })
   }
 
@@ -67,6 +69,10 @@ class PatternList extends React.Component {
         className={'js-pattern-dropdown pattern-dropdown' + (this.state.patternDropdown ? ' is-active' : '')}
         style={{maxHeight: this.props.height}}
         >
+        {(this.props.patterns.size && this.state.patternHistory.size
+          ? <div className='list-header'>Recent</div>
+          : null
+        )}
         <ul>
           {
             this.state.patternHistory.map(pattern => {
@@ -82,10 +88,10 @@ class PatternList extends React.Component {
             })
           }
         </ul>
-        { this.props.pattern.length && this.state.patternHistory.length
-            && <div className='list-divider'/>
-            || null
-        }
+        {(this.props.patterns.size && this.state.patternHistory.size
+          ? <div className='list-header'>Saved</div>
+          : null
+        )}
         <ul>
           {
             this.props.patterns.map(pattern => {

--- a/src/renderer/windows/MainWindow/InstanceContent/DatabaseContainer/KeyBrowser/PatternList/index.jsx
+++ b/src/renderer/windows/MainWindow/InstanceContent/DatabaseContainer/KeyBrowser/PatternList/index.jsx
@@ -33,7 +33,7 @@ class PatternList extends React.Component {
   updatePatternHistory(value) {
     let history = this.state.patternHistory
     const i = history.indexOf(value)
-    if(i != -1)  history = history.remove(index)
+    if(i != -1)  history = history.remove(i)
     history = history.unshift(value)
     this.setState({
       patternHistory: history.slice(0,5)

--- a/src/renderer/windows/MainWindow/InstanceContent/DatabaseContainer/KeyBrowser/PatternList/index.scss
+++ b/src/renderer/windows/MainWindow/InstanceContent/DatabaseContainer/KeyBrowser/PatternList/index.scss
@@ -65,15 +65,22 @@
       color: #fff;
     }
 
-    &:last-child {
-      font-family: system, -apple-system, ".SFNSDisplay-Regular", "Helvetica Neue", Helvetica, "Segoe UI", sans-serif;
-    }
   }
 }
 .manage-pattern-button {
   color: #116cd6;
+  font-family: inherit !important;
 
   span.icon {
     margin-right: 5px;
   }
+}
+
+.list-header{
+  padding: 2px 12px;
+  background: #f5f5f4;
+  color: #606061;
+  font-weight: bold;
+  font-size: .75rem;
+  opacity: .6;
 }

--- a/src/renderer/windows/MainWindow/InstanceContent/DatabaseContainer/index.scss
+++ b/src/renderer/windows/MainWindow/InstanceContent/DatabaseContainer/index.scss
@@ -47,8 +47,3 @@
     text-overflow: clip;
   }
 }
-
-.list-divider{
-  height: 1rem;
-  background: #f5f5f4;
-}

--- a/src/renderer/windows/MainWindow/InstanceContent/DatabaseContainer/index.scss
+++ b/src/renderer/windows/MainWindow/InstanceContent/DatabaseContainer/index.scss
@@ -47,3 +47,8 @@
     text-overflow: clip;
   }
 }
+
+.list-divider{
+  height: 1rem;
+  background: #f5f5f4;
+}


### PR DESCRIPTION
This remembers the latest 5 patterns that were not already saved. 

When the user types in a pattern and hits the Return key the pattern is added to the top of the list of suggestions. When a pattern is reused it is moved to the top of the list. When a sixth pattern is used, the oldest one is removed.

If the user enters a new pattern _and_ they have saved patterns, section headers are added to the list to visually separate saved patterns from recently used ones.

<img width="260" alt="Screen Shot 2020-10-01 at 8 54 49 PM" src="https://user-images.githubusercontent.com/1058893/94880387-61be5a80-0428-11eb-96ea-4055a53af8c4.png">
